### PR TITLE
Fix signup token in api customers

### DIFF
--- a/client/src/api/customers/index.js
+++ b/client/src/api/customers/index.js
@@ -39,7 +39,7 @@ class ApiCustomers {
 
     const config = {
       headers: {
-        Authorization: `Bearer ${token}}`,
+        Authorization: `Bearer ${token}`,
       },
     };
 


### PR DESCRIPTION
Mini fix pour enlever une accolade fermante dans `src/api/customers/index.js` !